### PR TITLE
Improved high memory usage cenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 /package-lock.json
 *.swp
+/yarn.lock

--- a/README.md
+++ b/README.md
@@ -252,12 +252,14 @@ const prerenderedHtml = require('!prerender-loader?string!./app.js');
 
 All options are ... optional.
 
-| Option        | Type    | Default            | Description                                                            |
-| ------------- | ------- | ------------------ | ---------------------------------------------------------------------- |
-| `string`      | boolean | false              | Output a JS module exporting an HTML String instead of the HTML itself |
-| `disabled`    | boolean | false              | Bypass the loader entirely (but still respect `options.string`)        |
-| `documentUrl` | string  | 'http://localhost' | Change the jsdom's URL (affects `window.location`, `document.URL`...)  |
-| `params`      | object  | null               | Options to pass to your prerender function                             |
+| Option             | Type    | Default            | Description                                                                         |
+| ------------------ | ------- | ------------------ | ----------------------------------------------------------------------------------- |
+| `string`           | boolean | false              | Output a JS module exporting an HTML String instead of the HTML itself              |
+| `disabled`         | boolean | false              | Bypass the loader entirely (but still respect `options.string`)                     |
+| `documentUrl`      | string  | 'http://localhost' | Change the jsdom's URL (affects `window.location`, `document.URL`...)               |
+| `params`           | object  | null               | Options to pass to your prerender function                                          |
+| `maxParallelTasks` | number  | null               | Limit the number o prerenders to execute in parallel (this should save some memory) |
+| `log`              | boolean | false              | Logs the start and end of the prerenders                                            |
 
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nettoolkit/prerender-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Painless universal prerendering for Webpack 5. Works great with html-webpack-plugin.",
   "main": "src/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/nettoolkit/prerender-loader#readme",
   "scripts": {
     "docs": "documentation readme -q --no-markdown-toc -a public -s Usage --sort-order alpha src",
-    "test": "jest --converage"
+    "test": "jest --coverage"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nettoolkit/prerender-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Painless universal prerendering for Webpack 5. Works great with html-webpack-plugin.",
   "main": "src/index.js",
   "source": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,8 @@ async function prerender (parentCompilation, request, options, inject, loader) {
   const outputOptions = {
     // fix: some plugins ignore/bypass outputfilesystem, so use a temp directory and ignore any writes.
     path: os.tmpdir(),
-    filename: FILENAME
+    filename: FILENAME,
+    publicPath: parentCompiler.options.output.publicPath
   };
 
   // Only copy over allowed plugins (excluding them breaks extraction entirely).


### PR DESCRIPTION
Here at my company, we use the prerender loader to allow us to reuse components/layouts from our app to generate email templates using react.
When we created a high number of email templates, the process started crashing because of high memory usage.

I made a few changes to the implementation so we can counter these issues:
- Added a new option called "maxParallelTasks" to limit the number of compilations ocurring at the same time, because all entries are compiled in parallel. If omitted, it will keep the old behaviour.
- Added a new option called "log" to allow us to track when a prerender starts and ends

Also fixed the test command 🙃 